### PR TITLE
Fix bug in authentication for redirect_uri

### DIFF
--- a/lib/omniauth/strategies/qualtrics.rb
+++ b/lib/omniauth/strategies/qualtrics.rb
@@ -1,14 +1,14 @@
-require 'omniauth-oauth2'
+require "omniauth-oauth2"
 
 module OmniAuth
   module Strategies
     class Qualtrics < OmniAuth::Strategies::OAuth2
-      option :name, 'qualtrics'
+      option :name, "qualtrics"
 
       option :client_options,
-             site: 'https://co1.qualtrics.com',
-             authorize_url: '/oauth2/auth',
-             token_url: '/oauth2/token'
+        site: "https://co1.qualtrics.com",
+        authorize_url: "/oauth2/auth",
+        token_url: "/oauth2/token"
 
       # Qualtrics does use state but we want to control it rather than letting
       # omniauth-oauth2 handle it.
@@ -18,7 +18,7 @@ module OmniAuth
 
       info do
         {
-          'url' => access_token.client.site
+          "url" => access_token.client.site
         }
       end
 
@@ -32,11 +32,11 @@ module OmniAuth
       def authorize_params
         # Only set state if it hasn't already been set
         options.authorize_params[:state] ||= SecureRandom.hex(24)
-        options.authorize_params[:scope] = 'manage:all'
-        params = options.authorize_params.merge(options_for('authorize'))
+        options.authorize_params[:scope] = "manage:all"
+        params = options.authorize_params.merge(options_for("authorize"))
         if OmniAuth.config.test_mode
           @env ||= {}
-          @env['rack.session'] ||= {}
+          @env["rack.session"] ||= {}
         end
         params
       end
@@ -44,5 +44,5 @@ module OmniAuth
   end
 end
 
-OmniAuth.config.add_camelization 'qualtrics', 'Qualtrics'
+OmniAuth.config.add_camelization "qualtrics", "Qualtrics"
 

--- a/lib/omniauth/strategies/qualtrics.rb
+++ b/lib/omniauth/strategies/qualtrics.rb
@@ -1,15 +1,14 @@
-require "omniauth-oauth2"
+require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
     class Qualtrics < OmniAuth::Strategies::OAuth2
-
-      option :name, "qualtrics"
+      option :name, 'qualtrics'
 
       option :client_options,
-            site:          "https://co1.qualtrics.com",
-            authorize_url: "/oauth2/auth",
-            token_url:     "/oauth2/token"
+             site: 'https://co1.qualtrics.com',
+             authorize_url: '/oauth2/auth',
+             token_url: '/oauth2/token'
 
       # Qualtrics does use state but we want to control it rather than letting
       # omniauth-oauth2 handle it.
@@ -19,8 +18,12 @@ module OmniAuth
 
       info do
         {
-          "url" => access_token.client.site
+          'url' => access_token.client.site
         }
+      end
+
+      def callback_url
+        full_host + script_name + callback_path
       end
 
       # Override authorize_params so that we can be deliberate about the value for state
@@ -29,16 +32,17 @@ module OmniAuth
       def authorize_params
         # Only set state if it hasn't already been set
         options.authorize_params[:state] ||= SecureRandom.hex(24)
-        params = options.authorize_params.merge(options_for("authorize"))
+        options.authorize_params[:scope] = 'manage:all'
+        params = options.authorize_params.merge(options_for('authorize'))
         if OmniAuth.config.test_mode
           @env ||= {}
-          @env["rack.session"] ||= {}
+          @env['rack.session'] ||= {}
         end
         params
       end
-
     end
   end
 end
 
-OmniAuth.config.add_camelization "qualtrics", "Qualtrics"
+OmniAuth.config.add_camelization 'qualtrics', 'Qualtrics'
+

--- a/omniauth-qualtrics.gemspec
+++ b/omniauth-qualtrics.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
 
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "omniauth", "~> 1.3"
   gem.add_dependency "omniauth-oauth2", "~> 1.4"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
It looks like there's an issue with how omniauth-oauth2 is constructing the redirect_uri for this that's causing qualtrics to reject authorization. We implemented the same workaround that the [twitch strategy did](https://github.com/WebTheoryLLC/omniauth-twitch/commit/3032f76de1c235e8a104fa25b650359ab62b4456) and it fixed the issue when we monkey patched this strategy in our project. Wanted to see if we could get the change upstream so that it would work for anyone else as well